### PR TITLE
Add console command to get latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Added
 - added `auto_generate` option to `links` section in config
-### Fixed
-- Fixed #7 where link generation failed if no version was available
+- added console command to get the latest version from the Changelog
 
 ### Fixed
+- Fixed #7 where link generation failed if no version was available
 - fixed issues with auto generation of links where unrelease template was wrong
 - fixed config hierarchy
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,18 @@ kacl-cli verify --json
 }
 ```
 
+## Print the current release version
+
+**Usage**
+
+```bash
+kacl-cli current
+```
+
+```
+0.1.2
+```
+
 ## Print a single release changelog
 
 **Usage**

--- a/kacl/kacl_cli.py
+++ b/kacl/kacl_cli.py
@@ -82,6 +82,17 @@ def add(ctx, section, message, modify):
 
 @cli.command()
 @click.pass_context
+def current(ctx):
+    """Returns the current version from the Changelog.
+    """
+    kacl_changelog, kacl_changelog_filepath = load_changelog(ctx)
+
+    current_version = kacl_changelog.current_version()
+    click.echo(current_version)
+
+
+@cli.command()
+@click.pass_context
 @click.argument('version', type=str)
 def get(ctx, version):
     """Returns a given version from the Changelog.


### PR DESCRIPTION
This command will return the latest version from the Changelog and print
it out on the console undecorated so it can be used in scripts easily.