### PR TITLE
Use gitlab variable for host url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-### Fixed
-
 ### Added
 - added `auto_generate` option to `links` section in config
 - added console command to get the latest version from the Changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+
 ### Added
 - added `auto_generate` option to `links` section in config
 - added console command to get the latest version from the Changelog
@@ -13,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed #7 where link generation failed if no version was available
 - fixed issues with auto generation of links where unrelease template was wrong
 - fixed config hierarchy
+- If running on gitlab-ci and no host URL is configued the URL is derived from CI_PROJECT_URL
+
 
 ## 0.2.17 - 2020-01-14
 ### Added

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ in order to generate the correct urls, `python-kacl` allows you to define three 
 kacl:
   git:
     links:
-        # The host url is optional and will be automatically determined using your the git repository
+        # The host url is optional and will be automatically determined using your the git repository. If run on gitlab CI the host will be determined by CI_PROJECT_URL if not specified here.
         host_url: https://github.com/mschmieder/kacl-cli
         compare_versions_template: '{host}/compare/v{previous_version}...v{version}'
         unreleased_changes_template: '{host}/tree/v{latest_version}...HEAD'

--- a/kacl/document.py
+++ b/kacl/document.py
@@ -474,14 +474,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
         initial_version_template = initial_version_template if initial_version_template else self.__config.links_initial_version_template()
 
         if host_url is None:
-            try:
-                repo = git.Repo(os.getcwd())
-                remote = repo.remote()
-                for url in remote.urls:
-                    host_url = url
-                    break
-            except:
-                raise KACLException("ERROR: Could not determine project url. Update your config or run within a valid git repository")
+            if 'CI_PROJECT_URL' in os.environ:
+                host_url = os.environ['CI_PROJECT_URL']
+            else:
+                try:
+                    repo = git.Repo(os.getcwd())
+                    remote = repo.remote()
+                    for url in remote.urls:
+                        host_url = url
+                        break
+                except:
+                    raise KACLException("ERROR: Could not determine project url. Update your config or run within a valid git repository")
 
         return LinkProvider(host_url=host_url,
                             compare_versions_template=compare_versions_template,


### PR DESCRIPTION
When no host URL is specified python-kacl uses the repo remote to derive the host URL. This results in unusable URLs when running on gitlab-ci.
With this merge request the environment variable CI_PROJECT_URL is used to derive the URL alternatively.