### PR TITLE
Added pre-commit hook for kacl-verify

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,4 +4,3 @@
   entry: kacl-cli verify
   language: python
   files: '^CHANGELOG.md'
-  always_run: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: kacl-verify
+  name: "verify kacl/changelog"
+  description: 'Veryfies if the changelog is in "keep-a-changelog" format.'
+  entry: kacl-cli verify
+  language: python
+  types: [python]
+  always_run: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: kacl-verify
   name: "verify kacl/changelog"
-  description: 'Veryfies if the changelog is in "keep-a-changelog" format.'
+  description: 'Verifies if the changelog is in "keep-a-changelog" format.'
   entry: kacl-cli verify
   language: python
-  types: [python]
+  files: '^CHANGELOG.md'
   always_run: true

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Commands:
   get      Returns a given version from the Changelog
   new      Creates a new changelog.
   release  Creates a release for the latest 'unreleased' changes.
-  verify   Veryfies if the changelog is in "keep-a-changelog" format.
+  verify   Verifies if the changelog is in "keep-a-changelog" format.
 ```
 
 
@@ -122,7 +122,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ```
 Usage: kacl-cli verify [OPTIONS]
 
-  Veryfies if the changelog is in "keep-a-changelog" format. Use '--json' get
+  Verifies if the changelog is in "keep-a-changelog" format. Use '--json' get
   JSON formatted output that can be easier integrated into CI workflows.
   Exit code is the number of identified errors.
 

--- a/kacl/kacl_cli.py
+++ b/kacl/kacl_cli.py
@@ -148,7 +148,7 @@ def generate(ctx, modify, host_url, compare_versions_template, unreleased_change
 @click.pass_context
 @click.option('--json', 'as_json', is_flag=True, help='Print validation output as json.')
 def verify(ctx, as_json):
-    """Veryfies if the changelog is in "keep-a-changelog" format.
+    """Verifies if the changelog is in "keep-a-changelog" format.
     Use '--json' get JSON formatted output that can be easier integrated into CI workflows.
     Exit code is the number of identified errors.
     """


### PR DESCRIPTION
This is a configuration file for [pre-commit](https://pre-commit.com/).

It enables pre-commit to use `kacl-verify` on a repository before committing new code.