### PR TITLE
[Fix] Newline handling and precommit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,4 @@
   entry: kacl-cli verify
   language: python
   files: '^CHANGELOG.md'
+  pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - added `--no-commit` option
 
+### Fixed
+- fixed handling of markdown newlines
+
 ## 0.2.23 - 2021-01-14
 ### Added
 - added `auto_generate` option to `links` section in config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Added
 - added `--no-commit` option
+- added `pre-commit` hook
 
 ### Fixed
 - fixed handling of markdown newlines

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A tool for verifying and modifying changelog in the [**K**eep-**A-C**hange-**L**
     - [From Source](#from-source)
     - [Pip Package](#pip-package)
     - [Docker](#docker)
+    - [pre-commit](#pre-commit)
   - [CLI](#cli)
   - [Create a Changelog](#create-a-changelog)
   - [Verify a Changelog](#verify-a-changelog)
@@ -67,6 +68,17 @@ The `kacl-cli` is defined as entrypoint. Therefore the image can be used like th
 
 ```bash
 docker -v $(pwd):$(pwd) -w $(pwd) mschmieder/kacl-cli:latest verify
+```
+
+### pre-commit
+
+The package can also be used as a pre-commit hook. Just add the following to your `.pre-commit-config.yaml`
+
+```yaml
+- repo: https://github.com/mschmieder/python-kacl
+  rev: 'v0.2.30'
+  hooks:
+    - id: kacl-verify
 ```
 
 ## CLI

--- a/kacl/document.py
+++ b/kacl/document.py
@@ -73,7 +73,7 @@ class KACLDocument:
 
         # 1.2 assert default content is in the header section
         for default_line in self.__config.default_content():
-            if default_line not in self.header().body().replace('\n', ''):
+            if default_line not in self.header().body().replace('\n', ' '):
                 header = self.header()
                 start_pos = header.raw().find(header.title())
                 end_pos = start_pos+len(header.title())
@@ -173,7 +173,7 @@ class KACLDocument:
                 # 3.4.1 bring everything into a single line
                 body = element.body()
                 body_clean = re.sub(r'\n\s+', '', body)
-                lines = body_clean.split('\n')
+                lines = body_clean.split('\n\n')
                 non_list_lines = [x for x in lines if not x.strip(
                 ).startswith('-') and len(x.strip()) > 0]
                 if len(non_list_lines) > 0:

--- a/tests/data/CHANGELOG_keepachangelog.com.md
+++ b/tests/data/CHANGELOG_keepachangelog.com.md
@@ -1,0 +1,151 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2017-06-20
+### Added
+- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).
+- Version navigation.
+- Links to latest released version in previous versions.
+- "Why keep a changelog?" section.
+- "Who needs a changelog?" section.
+- "How do I make a changelog?" section.
+- "Frequently Asked Questions" section.
+- New "Guiding Principles" sub-section to "How do I make a changelog?".
+- Simplified and Traditional Chinese translations from [@tianshuo](https://github.com/tianshuo).
+- German translation from [@mpbzh](https://github.com/mpbzh) & [@Art4](https://github.com/Art4).
+- Italian translation from [@azkidenz](https://github.com/azkidenz).
+- Swedish translation from [@magol](https://github.com/magol).
+- Turkish translation from [@karalamalar](https://github.com/karalamalar).
+- French translation from [@zapashcanon](https://github.com/zapashcanon).
+- Brazilian Portugese translation from [@Webysther](https://github.com/Webysther).
+- Polish translation from [@amielucha](https://github.com/amielucha) & [@m-aciek](https://github.com/m-aciek).
+- Russian translation from [@aishek](https://github.com/aishek).
+- Czech translation from [@h4vry](https://github.com/h4vry).
+- Slovak translation from [@jkostolansky](https://github.com/jkostolansky).
+- Korean translation from [@pierceh89](https://github.com/pierceh89).
+- Croatian translation from [@porx](https://github.com/porx).
+- Persian translation from [@Hameds](https://github.com/Hameds).
+- Ukrainian translation from [@osadchyi-s](https://github.com/osadchyi-s).
+
+### Changed
+- Start using "changelog" over "change log" since it's the common usage.
+- Start versioning based on the current English version at 0.3.0 to help
+translation authors keep things up-to-date.
+- Rewrite "What makes unicorns cry?" section.
+- Rewrite "Ignoring Deprecations" sub-section to clarify the ideal
+  scenario.
+- Improve "Commit log diffs" sub-section to further argument against
+  them.
+- Merge "Why can’t people just use a git log diff?" with "Commit log
+  diffs"
+- Fix typos in Simplified Chinese and Traditional Chinese translations.
+- Fix typos in Brazilian Portuguese translation.
+- Fix typos in Turkish translation.
+- Fix typos in Czech translation.
+- Fix typos in Swedish translation.
+- Improve phrasing in French translation.
+- Fix phrasing and spelling in German translation.
+
+### Removed
+- Section about "changelog" vs "CHANGELOG".
+
+## [0.3.0] - 2015-12-03
+### Added
+- RU translation from [@aishek](https://github.com/aishek).
+- pt-BR translation from [@tallesl](https://github.com/tallesl).
+- es-ES translation from [@ZeliosAriex](https://github.com/ZeliosAriex).
+
+## [0.2.0] - 2015-10-06
+### Changed
+- Remove exclusionary mentions of "open source" since this project can
+benefit both "open" and "closed" source projects equally.
+
+## [0.1.0] - 2015-10-06
+### Added
+- Answer "Should you ever rewrite a change log?".
+
+### Changed
+- Improve argument against commit logs.
+- Start following [SemVer](https://semver.org) properly.
+
+## [0.0.8] - 2015-02-17
+### Changed
+- Update year to match in every README example.
+- Reluctantly stop making fun of Brits only, since most of the world
+  writes dates in a strange way.
+
+### Fixed
+- Fix typos in recent README changes.
+- Update outdated unreleased diff link.
+
+## [0.0.7] - 2015-02-16
+### Added
+- Link, and make it obvious that date format is ISO 8601.
+
+### Changed
+- Clarified the section on "Is there a standard change log format?".
+
+### Fixed
+- Fix Markdown links to tag comparison URL with footnote-style links.
+
+## [0.0.6] - 2014-12-12
+### Added
+- README section on "yanked" releases.
+
+## [0.0.5] - 2014-08-09
+### Added
+- Markdown links to version tags on release headings.
+- Unreleased section to gather unreleased changes and encourage note
+keeping prior to releases.
+
+## [0.0.4] - 2014-08-09
+### Added
+- Better explanation of the difference between the file ("CHANGELOG")
+and its function "the change log".
+
+### Changed
+- Refer to a "change log" instead of a "CHANGELOG" throughout the site
+to differentiate between the file and the purpose of the file — the
+logging of changes.
+
+### Removed
+- Remove empty sections from CHANGELOG, they occupy too much space and
+create too much noise in the file. People will have to assume that the
+missing sections were intentionally left out because they contained no
+notable changes.
+
+## [0.0.3] - 2014-08-09
+### Added
+- "Why should I care?" section mentioning The Changelog podcast.
+
+## [0.0.2] - 2014-07-10
+### Added
+- Explanation of the recommended reverse chronological release ordering.
+
+## [0.0.1] - 2014-05-31
+### Added
+- This CHANGELOG file to hopefully serve as an evolving example of a
+  standardized open source project CHANGELOG.
+- CNAME file to enable GitHub Pages custom domain
+- README now contains answers to common questions about CHANGELOGs
+- Good examples and basic guidelines, including proper date formatting.
+- Counter-examples: "What makes unicorns cry?"
+
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.0...v1.0.0
+[0.3.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.8...v0.1.0
+[0.0.8]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.7...v0.0.8
+[0.0.7]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.6...v0.0.7
+[0.0.6]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.5...v0.0.6
+[0.0.5]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.4...v0.0.5
+[0.0.4]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.3...v0.0.4
+[0.0.3]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/v0.0.1

--- a/tests/test_kacl.py
+++ b/tests/test_kacl.py
@@ -125,6 +125,24 @@ class TestKacl(TestCase):
         validation = changelog.validate()
         self.assertGreaterEqual(len(validation.errors()), 0)
 
+    def test_valid_keepachangelogcom(self):
+        changelog_file = os.path.join(os.path.dirname(
+            os.path.realpath(__file__)), "data/CHANGELOG_keepachangelog.com.md")
+        changelog = kacl.load(changelog_file)
+        self.assertTrue(changelog.is_valid())
+
+        validation = changelog.validate()
+        self.assertGreaterEqual(len(validation.errors()), 0)
+
+    def test_valid_project_changelog(self):
+        changelog_file = os.path.join(os.path.dirname(os.path.dirname(
+            os.path.realpath(__file__))), "CHANGELOG.md")
+        changelog = kacl.load(changelog_file)
+        self.assertTrue(changelog.is_valid())
+
+        validation = changelog.validate()
+        self.assertGreaterEqual(len(validation.errors()), 0)
+
     def test_load_empty(self):
         changelog = kacl.parse("")
         self.assertFalse(changelog.is_valid())


### PR DESCRIPTION
Hey. It's me again.

I'm sorry to say, but there were a couple of issues with both PRs from yesterday:

- Newlines are actual whitespace in markdown, just not an actual newline. I've corrected that.
- It was also not complete, because it did not fixed the check 3.4: `check that only list elements are in the sections`. I only noticed it when I wrote the test to validate the first issue.
- `pre-commit` hook fails, because it tries to run `kacl-cli verify CHANGELOG.md`, which does not match the expected args.

That was the bad news, the good news is, that's all fixed in this PR:

- Fixed the newline / whitespace issue AND added a test that validates a copy pasted version of the example given in keepachangelog.com.
- Also added a test that validates our own CHANGELOG. It was right there, I just thought 'why not?'.
- Added `pass_filenames = false` to the pre-commit, so that it doesn't pass the CHANGELOG file into the command arguments.
- Documented on how to include a `pre-commit` hook into a project.
- Updated CHANGELOG.
- Last, but not least, I actually validated the changes, with the project I intend to use `python-kacl` on. I had done that with the newline fix, but there was a trailing whitespace that fooled me.

I do have a small request though: As you can see on the `README.md` changes, I pinned a version to the hook. This is highly recommended by `pre-commit`. If I use `rev: master` for example, it shouts something like this:
```
[WARNING] The 'rev' field of repo 'https://github.com/mschmieder/python-kacl' appears to be a mutable reference (moving tag / branch).  Mutable references are never updated after first install and are not supported.  See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.  Hint: `pre-commit autoupdate` often fixes this.
```
So, my request is tag the next released version here on github as `v0.2.30`.

Okay, that's it.

Let me know, if anything comes up and thank you!